### PR TITLE
添加对依赖API鉴权依赖的描述

### DIFF
--- a/tools/us3cli/questions.md
+++ b/tools/us3cli/questions.md
@@ -71,8 +71,8 @@ qps代表每秒请求数量限制，如qps为1，那么该请求会限制在1秒
   
 ### 问题原因
   
-  US3令牌（公钥以TOKEN_为首）只支持对bucket文件操作，在使用需要ApiKey鉴权的命令时会报错：ERROR Signature VerifyAC Error
+  US3令牌（公钥以TOKEN_为首）仅支持对bucket文件相关操作，在使用需要ApiKey鉴权的命令时会报错：ERROR Signature VerifyAC Error
   
 ### 解决方案
   
-  鉴权改用ApiKey
+  鉴权改用ApiKey方式

--- a/tools/us3cli/questions.md
+++ b/tools/us3cli/questions.md
@@ -66,3 +66,13 @@ qps代表每秒请求数量限制，如qps为1，那么该请求会限制在1秒
 ### 解决方案
 
 在bin目录下执行`us3cli update`。
+
+## 报错 Signature VerifyAC Error
+  
+### 问题原因
+  
+  US3令牌（公钥以TOKEN_为首）只支持对bucket文件操作，在使用需要ApiKey鉴权的命令时会报错：ERROR Signature VerifyAC Error
+  
+### 解决方案
+  
+  鉴权改用ApiKey


### PR DESCRIPTION
使用US3令牌时，运行需要ApiKey鉴权的命令时会报错：ERROR Signature VerifyAC Error